### PR TITLE
repair SLOAD functionality

### DIFF
--- a/DBGEREUM.py
+++ b/DBGEREUM.py
@@ -2097,7 +2097,7 @@ class Dbgereum:
                         self.stack.append(self.storage[i].split(":")[1])
                         break
                 else:
-                    self.stack.append(0)
+                    self.stack.append(hex(0)[2:])
                 self.ip += 1
             except:
                 print("[SLOAD] Smth went wrong :( - Popped value from empty stack...")

--- a/DBGEREUM.py
+++ b/DBGEREUM.py
@@ -2095,7 +2095,7 @@ class Dbgereum:
                 for i in range(len(self.storage) - 1, 0, -1):
                     if int(self.storage[i].split(":")[0], 16) == key:
                         self.stack.append(self.storage[i].split(":")[1])
-                    break
+                        break
                 else:
                     self.stack.append(0)
                 self.ip += 1

--- a/DBGEREUM.py
+++ b/DBGEREUM.py
@@ -2092,12 +2092,13 @@ class Dbgereum:
         elif command == 0x54:
             try:
                 key = int(self.stack.pop(), 16)
-                try:
-                    self.stack.append(self.storage[key])
-                    self.ip += 1
-                except:
-                    print("[SLOAD] key-value query doesn't exist. Implement storage parsing before exec.")
-                    exit()
+                for i in range(len(self.storage) - 1, 0, -1):
+                    if int(self.storage[i].split(":")[0], 16) == key:
+                        self.stack.append(self.storage[i].split(":")[1])
+                    break
+                else:
+                    self.stack.append(0)
+                self.ip += 1
             except:
                 print("[SLOAD] Smth went wrong :( - Popped value from empty stack...")
                 exit()


### PR DESCRIPTION
@malikDaCoda, you could be the main fork for this project. The main project seems to be abandoned.

The SLOAD function does not work at all. The implementation of this PR could be more efficient, but for my purposes, it works.

Reproduction: Start `python DBGEREUM.py`, Select "File" -> "Open bytes" and enter `60ff60405560405460005260006020f3`.

Press "STEP" repeatedly. On the 5th press, when executing SLOAD, the application will crash and the window will close (without the current fix). With the current fix, it continues correctly.

By the way, this uses Python's not-so-well-known "for-else" construct to assign the default value 0 for SLOAD. (In the evm, storage is assumed to be filled with all zeros initially, so that would be the default value when the key isn't found).